### PR TITLE
'Tree' attribute removal for gibbsFull initialization + test case minor fixes

### DIFF
--- a/PAPER/gibbsSampling.py
+++ b/PAPER/gibbsSampling.py
@@ -308,6 +308,9 @@ def gibbsFull(graf, Burn=40, M=50, gap=1, alpha=0, beta=1, K=1,
         tree2root = [v]
         mypi = sampleOrdering(graf, tree2root, alpha, beta)
 
+        for e in graf.es.select(_within =mypi[0:K]):
+            e['tree'] = False
+
 
     if ("node_tree_coo" in options):
         node_tree_coo = options["node_tree_coo"]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -57,13 +57,13 @@ def test_gibbs_single_root_with_estimation():
     graf = createNoisyGraph(n, m, alpha=alpha, beta=beta, K=K)[0]
         
     res = gibbsToConv(graf, Burn=20, M=40, DP=False, method="full",
-                                   K=1, alpha=0, beta=0, tol=0.02)
+                                   K=1, tol=0.02)
         
     assert abs(sum(res[0]) - 1) < 1e-3
             
             
     res2 = gibbsToConv(graf, Burn=20, M=40, DP=False, method="collapsed",
-                                   K=1, alpha=0, beta=0, tol=0.02)
+                                   K=1, tol=0.02)
     
     assert sum( np.abs( res[0] - res2[0] ))/2 < 0.2    
     
@@ -72,7 +72,7 @@ def test_gibbs_single_root_with_estimation():
 def test_fixed_K_roots():
     
     n = 50
-    K = 2
+    K = 3
     m = 70
     
     alpha = 1


### PR DESCRIPTION
- PAPER/gibbsSampling.py 

   gibbsFull: Removed 'tree' attribute of edges between roots during initialization stage 

- tests/test_basic.py 

   test_random_K_roots: changed K to 3 to reflect "gibbsFull" bug fix

   test_gibbs_single_root_with_estimation: removed "alpha = 0, beta = 0" for parameter estimation (triggers when alpha, beta = None)

- **TODO:** tests/test_basic.py 

   ln 34, test_gibbs_single_root: "ValueError: Total of weights must be greater than zero" for gibbsGraft
